### PR TITLE
Avoid using <c*> headers, avoid vasprintf

### DIFF
--- a/include/jaffarCommon/bitwise.hpp
+++ b/include/jaffarCommon/bitwise.hpp
@@ -5,8 +5,8 @@
  * @brief Contains common functions related to bitwise operations
  */
 
-#include <cstdint>
 #include <stddef.h>
+#include <stdint.h>
 #include "exceptions.hpp"
 
 namespace jaffarCommon

--- a/include/jaffarCommon/concurrent.hpp
+++ b/include/jaffarCommon/concurrent.hpp
@@ -5,6 +5,7 @@
  * @brief Containers designed for fast parallel, mutual exclusive access
  */
 
+#include <stddef.h>
 #include <deque>
 #include <mutex>
 #include <atomic_queue/include/atomic_queue/atomic_queue.h>

--- a/include/jaffarCommon/deserializers/base.hpp
+++ b/include/jaffarCommon/deserializers/base.hpp
@@ -5,8 +5,8 @@
  * @brief Contains the base class for the data deserializers
  */
 
-#include <cstddef>
-#include <cstdint>
+#include <stddef.h>
+#include <stdint.h>
 
 namespace jaffarCommon
 {

--- a/include/jaffarCommon/deserializers/contiguous.hpp
+++ b/include/jaffarCommon/deserializers/contiguous.hpp
@@ -5,7 +5,7 @@
  * @brief Contains the contiguous data deserializer
  */
 
-#include <cstring>
+#include <string.h>
 #include <limits>
 #include "../exceptions.hpp"
 #include "base.hpp"

--- a/include/jaffarCommon/exceptions.hpp
+++ b/include/jaffarCommon/exceptions.hpp
@@ -5,10 +5,9 @@
  * @brief Contains common functions for exception throwing
  */
 
-#include <cstdarg>
-#include <cstdio>
+#include <stdarg.h>
+#include <stdio.h>
 #include <stdexcept>
-#include <unistd.h>
 #include "string.hpp"
 
 namespace jaffarCommon
@@ -41,8 +40,22 @@ __INLINE__ void throwException [[noreturn]] (const char *exceptionType, const ch
   char   *outstr = 0;
   va_list ap;
   va_start(ap, format);
-  int ret = vasprintf(&outstr, format, ap);
-  if (ret == 0) throw std::invalid_argument("Failed processing exception reason");
+  int ret = vsnprintf(nullptr, 0, format, ap);
+  va_end(ap);
+  if (ret < 0) throw std::invalid_argument("Failed processing exception reason");
+
+  outstr = (char *)malloc(ret + 1);
+  if (outstr == nullptr) throw std::invalid_argument("Failed processing exception reason");
+
+  va_start(ap, format);
+  ret = vsnprintf(outstr, ret + 1, format, ap);
+  va_end(ap);
+  if (ret < 0)
+  {
+    free(outstr);
+    throw std::invalid_argument("Failed processing exception reason");
+  }
+
   std::string outString = outstr;
   free(outstr);
 

--- a/include/jaffarCommon/hash.hpp
+++ b/include/jaffarCommon/hash.hpp
@@ -5,8 +5,8 @@
  * @brief Contains common function related to hashing
  */
 
+#include <stdio.h>
 #include <string>
-#include <cstdio>
 #include <metrohash128/metrohash128.h>
 #include <sha1/sha1.hpp>
 

--- a/include/jaffarCommon/json.hpp
+++ b/include/jaffarCommon/json.hpp
@@ -4,7 +4,7 @@
  * @file json.hpp
  * @brief Contains common functions related to JSON manipulation
  */
-#include <cstdlib>
+#include <stdlib.h>
 #include <json/single_include/nlohmann/json.hpp>
 #include "exceptions.hpp"
 

--- a/include/jaffarCommon/loggers/ncurses.hpp
+++ b/include/jaffarCommon/loggers/ncurses.hpp
@@ -5,8 +5,8 @@
  * @brief Contains common functions related to output and logging using NCurses
  */
 
-#include <cstdarg>
-#include <cstdio>
+#include <stdarg.h>
+#include <stdio.h>
 #include <stdexcept>
 #include <ncurses.h>
 #include <unistd.h>

--- a/include/jaffarCommon/loggers/stdio.hpp
+++ b/include/jaffarCommon/loggers/stdio.hpp
@@ -5,10 +5,9 @@
  * @brief Contains common functions related to output and logging using stdio
  */
 
-#include <cstdarg>
-#include <cstdio>
+#include <stdarg.h>
+#include <stdio.h>
 #include <stdexcept>
-#include <unistd.h>
 #include "../string.hpp"
 
 namespace jaffarCommon

--- a/include/jaffarCommon/parallel.hpp
+++ b/include/jaffarCommon/parallel.hpp
@@ -5,7 +5,8 @@
  * @brief Definitions and utilities for parallel execution
  */
 
-#include <cstddef>
+#include <stddef.h>
+#include <stdint.h>
 #include <omp.h>
 
 namespace jaffarCommon

--- a/include/jaffarCommon/serializers/base.hpp
+++ b/include/jaffarCommon/serializers/base.hpp
@@ -5,8 +5,8 @@
  * @brief Contains the base class for the data serializers
  */
 
-#include <cstddef>
-#include <cstdint>
+#include <stddef.h>
+#include <stdint.h>
 
 namespace jaffarCommon
 {

--- a/include/jaffarCommon/serializers/contiguous.hpp
+++ b/include/jaffarCommon/serializers/contiguous.hpp
@@ -5,7 +5,7 @@
  * @brief Contains the contiguous data serializer
  */
 
-#include <cstring>
+#include <string.h>
 #include <limits>
 #include "../exceptions.hpp"
 #include "base.hpp"

--- a/include/jaffarCommon/serializers/differential.hpp
+++ b/include/jaffarCommon/serializers/differential.hpp
@@ -5,7 +5,7 @@
  * @brief Contains the differential data serializer
  */
 
-#include <cstring>
+#include <string.h>
 #include <limits>
 #include <xdelta3/xdelta3.h>
 #include "base.hpp"

--- a/include/jaffarCommon/string.hpp
+++ b/include/jaffarCommon/string.hpp
@@ -5,12 +5,12 @@
  * @brief Contains common functions related to manipulating strings
  */
 
-#include <cstdarg>
+#include <stdarg.h>
+#include <stdio.h>
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <algorithm>
-#include <cstdio>
 
 namespace jaffarCommon
 {
@@ -63,8 +63,21 @@ __INLINE__ std::string formatString(const char *format, ...)
   char   *outstr = 0;
   va_list ap;
   va_start(ap, format);
-  int ret = vasprintf(&outstr, format, ap);
-  if (ret == 0) return "";
+  int ret = vsnprintf(nullptr, 0, format, ap);
+  va_end(ap);
+  if (ret < 0) return "";
+
+  outstr = (char *)malloc(ret + 1);
+  if (outstr == nullptr) return "";
+
+  va_start(ap, format);
+  ret = vsnprintf(outstr, ret + 1, format, ap);
+  va_end(ap);
+  if (ret < 0)
+  {
+    free(outstr);
+    return "";
+  }
 
   std::string outString = outstr;
   free(outstr);

--- a/include/jaffarCommon/timing.hpp
+++ b/include/jaffarCommon/timing.hpp
@@ -5,6 +5,7 @@
  * @brief Contains common functions related to time measurement
  */
 
+#include <stddef.h>
 #include <chrono>
 #include <type_traits>
 


### PR DESCRIPTION
These make the headers more friendly to an MSVC environment (i.e. with official Windows headers rather than msys2/etc headers)